### PR TITLE
feat: add hotel detail booking deeplinks

### DIFF
--- a/src/api/hotelApi.ts
+++ b/src/api/hotelApi.ts
@@ -36,6 +36,59 @@ export interface HotelOfferItem {
   checkout: { until: string } | null;
   is_free_cancellable: boolean;
   badges?: Array<{ id: string; text: string }>;
+  /** 백엔드가 property 노드에 주입하는 Booking.com 딥링크 */
+  property?: { bookingUrl?: string; name?: string };
+}
+
+/* ── 호텔 상세 타입 ── */
+
+export interface HotelRoomPhoto {
+  url: string;
+  url_1440?: string;
+}
+
+export interface HotelRoom {
+  block_id?: string;
+  room_name?: string;
+  name_without_policy?: string;
+  min_price?: { price: number; currency: string };
+  max_occupancy?: number;
+  room_surface_in_m2?: number;
+  is_free_cancellable?: number | boolean;
+  photos?: HotelRoomPhoto[];
+  highlights?: Array<{ translated_name: string }>;
+}
+
+export interface HotelDetailsData {
+  hotel_id?: number;
+  hotel_name?: string;
+  address?: string;
+  city?: string;
+  url?: string;
+  review_score?: number;
+  review_score_word?: string;
+  review_nr?: number;
+  checkin?: { from: string; until?: string };
+  checkout?: { from?: string; until: string };
+  block?: HotelRoom[];
+  photos?: Array<{ url_original: string; url_max300?: string }>;
+  hotel_text?: { description?: string };
+}
+
+export interface HotelDetailsResponse {
+  status?: boolean;
+  data?: HotelDetailsData;
+}
+
+export interface HotelDetailsInput {
+  hotelId: string;
+  arrivalDate: string;
+  departureDate: string;
+  adults?: number;
+  childrenAge?: string;
+  roomQty?: number;
+  languageCode?: string;
+  currencyCode?: string;
 }
 
 export interface HotelOffersResponse {
@@ -139,6 +192,23 @@ export async function fetchHotelFilterOptions(
   const res = await fetch(
     `${API_BASE}/api/v1/hotels/filter-options?${buildQuery(params)}`,
   );
+  if (!res.ok) throw new Error(`API 오류: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchHotelDetails(
+  params: HotelDetailsInput,
+): Promise<HotelDetailsResponse> {
+  const p = new URLSearchParams();
+  p.set("hotelId", params.hotelId);
+  p.set("arrivalDate", params.arrivalDate);
+  p.set("departureDate", params.departureDate);
+  if (params.adults != null) p.set("adults", String(params.adults));
+  if (params.childrenAge) p.set("childrenAge", params.childrenAge);
+  if (params.roomQty != null) p.set("roomQty", String(params.roomQty));
+  if (params.languageCode) p.set("languageCode", params.languageCode);
+  if (params.currencyCode) p.set("currencyCode", params.currencyCode);
+  const res = await fetch(`${API_BASE}/api/v1/hotels/details?${p}`);
   if (!res.ok) throw new Error(`API 오류: ${res.status}`);
   return res.json();
 }

--- a/src/components/flightDetail/FareActionModal.tsx
+++ b/src/components/flightDetail/FareActionModal.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 interface FareActionModalProps {
   fareName: string;
+  bookingUrl?: string;
   onReserve: () => void;
   onSaveToWorkspace: () => void;
   onClose: () => void;
@@ -13,6 +14,7 @@ interface FareActionModalProps {
  */
 export default function FareActionModal({
   fareName,
+  bookingUrl,
   onReserve,
   onSaveToWorkspace,
   onClose,
@@ -52,17 +54,38 @@ export default function FareActionModal({
         {/* 버튼 목록 */}
         <div className="flex flex-col gap-2 px-5 py-4">
           {/* 예약하기 */}
-          <button
-            type="button"
-            onClick={onReserve}
-            className={[
-              "w-full py-3 rounded-xl font-pretendard text-body2 font-semibold",
-              "bg-primary text-gray-900 border-none cursor-pointer",
-              "hover:brightness-95 transition-all",
-            ].join(" ")}
-          >
-            예약하기
-          </button>
+          {bookingUrl ? (
+            <a
+              href={bookingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={onReserve}
+              className={[
+                "w-full py-3 rounded-xl font-pretendard text-body2 font-semibold",
+                "bg-primary text-gray-900 border-none cursor-pointer",
+                "hover:brightness-95 transition-all",
+                "flex items-center justify-center gap-1.5 no-underline",
+              ].join(" ")}
+            >
+              Booking.com에서 예약하기
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M5.5 3H3C2.448 3 2 3.448 2 4v7c0 .552.448 1 1 1h7c.552 0 1-.448 1-1V8.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+                <path d="M8 2h4v4M12 2L6.5 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </a>
+          ) : (
+            <button
+              type="button"
+              onClick={onReserve}
+              className={[
+                "w-full py-3 rounded-xl font-pretendard text-body2 font-semibold",
+                "bg-primary text-gray-900 border-none cursor-pointer",
+                "hover:brightness-95 transition-all",
+              ].join(" ")}
+            >
+              예약하기
+            </button>
+          )}
 
           {/* 항공일정 저장하기 */}
           <button

--- a/src/components/hotel/HotelCard.tsx
+++ b/src/components/hotel/HotelCard.tsx
@@ -2,6 +2,7 @@ import { type HotelOfferItem } from "@/api/hotelApi";
 
 interface HotelCardProps {
   hotel: HotelOfferItem;
+  onClick?: () => void;
 }
 
 function Stars({ count }: { count: number | null }) {
@@ -17,17 +18,23 @@ function Stars({ count }: { count: number | null }) {
   );
 }
 
-export default function HotelCard({ hotel }: HotelCardProps) {
+export default function HotelCard({ hotel, onClick }: HotelCardProps) {
   const price =
     hotel.min_total_price ??
     hotel.composite_price_breakdown?.gross_amount?.value;
 
   return (
-    <a
-      href={hotel.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="flex bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-md transition-shadow no-underline"
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+      className="flex bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-md transition-shadow cursor-pointer"
     >
       {/* 썸네일 */}
       {hotel.main_photo_url ? (
@@ -120,6 +127,6 @@ export default function HotelCard({ hotel }: HotelCardProps) {
           )}
         </div>
       </div>
-    </a>
+    </div>
   );
 }

--- a/src/components/hotel/HotelDetailModal.tsx
+++ b/src/components/hotel/HotelDetailModal.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useState } from "react";
+import {
+  fetchHotelDetails,
+  type HotelOfferItem,
+  type HotelDetailsData,
+  type HotelRoom,
+} from "@/api/hotelApi";
+
+interface HotelDetailModalProps {
+  hotel: HotelOfferItem;
+  arrivalDate: string;
+  departureDate: string;
+  adults: number;
+  onClose: () => void;
+}
+
+function formatPrice(price: number, currency = "KRW"): string {
+  if (currency === "KRW") return `₩${Math.round(price).toLocaleString("ko-KR")}`;
+  return `${currency} ${price.toLocaleString()}`;
+}
+
+function Stars({ count }: { count: number | null }) {
+  if (!count) return null;
+  return (
+    <div className="flex items-center gap-0.5">
+      {Array.from({ length: Math.min(Math.round(count), 5) }).map((_, i) => (
+        <span key={i} className="text-primary leading-none">★</span>
+      ))}
+    </div>
+  );
+}
+
+function RoomCard({ room }: { room: HotelRoom }) {
+  const photo = room.photos?.[0]?.url;
+  const isFree = room.is_free_cancellable === 1 || room.is_free_cancellable === true;
+
+  return (
+    <div className="flex gap-4 bg-gray-50 rounded-xl border border-gray-200 overflow-hidden">
+      {photo ? (
+        <img
+          src={photo}
+          alt={room.room_name ?? "객실"}
+          className="w-32 h-28 object-cover shrink-0"
+        />
+      ) : (
+        <div className="w-32 h-28 bg-gray-200 shrink-0 flex items-center justify-center">
+          <span className="font-pretendard text-body5 text-gray-400">이미지 없음</span>
+        </div>
+      )}
+
+      <div className="flex flex-1 min-w-0 py-3 pr-4 justify-between gap-3">
+        <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+          <h4 className="font-pretendard text-body2 font-semibold text-gray-900 m-0 truncate">
+            {room.name_without_policy ?? room.room_name ?? "객실"}
+          </h4>
+
+          <div className="flex items-center gap-2 flex-wrap">
+            {isFree && (
+              <span className="font-pretendard text-body5 text-green-700 bg-green-50 border border-green-200 px-1.5 py-0.5 rounded">
+                무료 취소
+              </span>
+            )}
+            {room.max_occupancy != null && (
+              <span className="font-pretendard text-body5 text-gray-500">
+                최대 {room.max_occupancy}인
+              </span>
+            )}
+            {room.room_surface_in_m2 != null && (
+              <span className="font-pretendard text-body5 text-gray-500">
+                {room.room_surface_in_m2}m²
+              </span>
+            )}
+          </div>
+
+          {room.highlights && room.highlights.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {room.highlights.slice(0, 2).map((h, i) => (
+                <span key={i} className="font-pretendard text-body5 text-blue-700 bg-blue-50 border border-blue-200 px-1.5 py-0.5 rounded">
+                  {h.translated_name}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {room.min_price != null && (
+          <div className="text-right shrink-0">
+            <p className="font-pretendard text-body5 text-gray-400 m-0">1박</p>
+            <p className="font-pretendard text-body1 font-bold text-gray-900 m-0">
+              {formatPrice(room.min_price.price, room.min_price.currency)}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HotelDetailContent({ data }: { data: HotelDetailsData }) {
+  const mainPhoto = data.photos?.[0]?.url_original ?? data.photos?.[0]?.url_max300;
+  const rooms = data.block ?? [];
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* 호텔 기본 정보 */}
+      <div className="flex gap-4">
+        {mainPhoto && (
+          <img
+            src={mainPhoto}
+            alt={data.hotel_name ?? "호텔"}
+            className="w-48 h-36 object-cover rounded-xl shrink-0"
+          />
+        )}
+        <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+          {data.review_score != null && (
+            <div className="flex items-center gap-2">
+              <span className="font-pretendard text-body3 font-bold bg-gray-900 text-white px-2.5 py-1 rounded-lg">
+                {data.review_score.toFixed(1)}
+              </span>
+              {data.review_score_word && (
+                <span className="font-pretendard text-body4 text-gray-600">
+                  {data.review_score_word}
+                </span>
+              )}
+              {data.review_nr != null && (
+                <span className="font-pretendard text-body5 text-gray-400">
+                  후기 {data.review_nr.toLocaleString()}개
+                </span>
+              )}
+            </div>
+          )}
+
+          {data.address && (
+            <p className="font-pretendard text-body4 text-gray-600 m-0">
+              {data.address}
+              {data.city ? `, ${data.city}` : ""}
+            </p>
+          )}
+
+          <div className="flex gap-4 mt-1">
+            {data.checkin?.from && (
+              <div>
+                <p className="font-pretendard text-body5 text-gray-400 m-0">체크인</p>
+                <p className="font-pretendard text-body4 text-gray-700 m-0">{data.checkin.from}~</p>
+              </div>
+            )}
+            {data.checkout?.until && (
+              <div>
+                <p className="font-pretendard text-body5 text-gray-400 m-0">체크아웃</p>
+                <p className="font-pretendard text-body4 text-gray-700 m-0">~{data.checkout.until}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 객실 목록 */}
+      {rooms.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <h3 className="font-pretendard text-body1 font-semibold text-gray-900 m-0">
+            이용 가능한 객실
+          </h3>
+          {rooms.map((room, i) => (
+            <RoomCard key={room.block_id ?? i} room={room} />
+          ))}
+        </div>
+      )}
+
+      {rooms.length === 0 && (
+        <div className="py-8 text-center">
+          <p className="font-pretendard text-body3 text-gray-500 m-0">
+            이용 가능한 객실 정보가 없어요
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function HotelDetailModal({
+  hotel,
+  arrivalDate,
+  departureDate,
+  adults,
+  onClose,
+}: HotelDetailModalProps) {
+  const [detailData, setDetailData] = useState<HotelDetailsData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  /* detail API url → 백엔드 주입 딥링크(날짜 포함) → 검색 결과 url 순 우선순위 */
+  const bookingUrl = detailData?.url ?? hotel.property?.bookingUrl ?? hotel.url;
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    fetchHotelDetails({
+      hotelId: String(hotel.hotel_id),
+      arrivalDate,
+      departureDate,
+      adults,
+      languageCode: "ko",
+      currencyCode: "KRW",
+    })
+      .then((res) => {
+        if (cancelled) return;
+        if (res.data) {
+          setDetailData(res.data);
+        } else {
+          setError("상세 정보를 불러올 수 없어요");
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "오류가 발생했어요");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hotel.hotel_id, arrivalDate, departureDate, adults]);
+
+  /* ESC로 닫기 */
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] flex flex-col overflow-hidden">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-gray-100 shrink-0">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <Stars count={hotel.class} />
+            <h2 className="font-pretendard text-body1 font-semibold text-gray-900 m-0 truncate">
+              {hotel.name}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-3 w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 text-gray-400 border-none bg-transparent cursor-pointer shrink-0"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* 바디 (스크롤 가능) */}
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {isLoading && (
+            <div className="flex flex-col items-center justify-center py-16 gap-3">
+              <div className="w-6 h-6 border-2 border-gray-300 border-t-gray-700 rounded-full animate-spin" />
+              <p className="font-pretendard text-body3 text-gray-500 m-0">
+                호텔 정보를 불러오는 중...
+              </p>
+            </div>
+          )}
+
+          {error && !isLoading && (
+            <div className="py-12 text-center">
+              <p className="font-pretendard text-body3 text-red-500 m-0">{error}</p>
+            </div>
+          )}
+
+          {!isLoading && !error && detailData && (
+            <HotelDetailContent data={detailData} />
+          )}
+        </div>
+
+        {/* 푸터 */}
+        <div className="px-6 py-4 border-t border-gray-100 shrink-0">
+          <a
+            href={bookingUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={[
+              "flex items-center justify-center gap-2 w-full py-3 rounded-xl",
+              "font-pretendard text-body2 font-semibold text-gray-900 no-underline",
+              "bg-primary hover:brightness-95 transition-all cursor-pointer",
+            ].join(" ")}
+          >
+            Booking.com에서 예약하기
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <path d="M5.5 3H3C2.448 3 2 3.448 2 4v7c0 .552.448 1 1 1h7c.552 0 1-.448 1-1V8.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+              <path d="M8 2h4v4M12 2L6.5 7.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/FlightDetailPage.tsx
+++ b/src/pages/FlightDetailPage.tsx
@@ -472,6 +472,7 @@ export default function FlightDetailPage() {
       {activeFareToken && !showWorkspaceModal && (
         <FareActionModal
           fareName={activeFareName}
+          bookingUrl={offer?.bookingUrl}
           onReserve={() => setActiveFareToken(null)}
           onSaveToWorkspace={() => {
             setActiveFareToken(null);

--- a/src/pages/HotelSearchPage.tsx
+++ b/src/pages/HotelSearchPage.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import SearchModeBar from "@/components/SearchModeBar";
 import HotelCard from "@/components/hotel/HotelCard";
+import HotelDetailModal from "@/components/hotel/HotelDetailModal";
 import HotelFilterPanel from "@/components/hotel/HotelFilterPanel";
 import { useHotelSearch } from "@/hooks/useHotelSearch";
+import { type HotelOfferItem } from "@/api/hotelApi";
 import { type HotelSearchBarParams } from "@/components/HotelSearchBar";
 import {
   type FlightSearchParams,
@@ -43,6 +45,7 @@ export function buildHotelSearchParams(p: HotelSearchBarParams): URLSearchParams
 export default function HotelSearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const [selectedHotel, setSelectedHotel] = useState<HotelOfferItem | null>(null);
 
   const parsedParams = parseParams(searchParams);
   const sortBy = searchParams.get("sortBy") ?? "price";
@@ -237,11 +240,25 @@ export default function HotelSearchPage() {
             )}
 
             {hotels.map((hotel) => (
-              <HotelCard key={hotel.hotel_id} hotel={hotel} />
+              <HotelCard
+                key={hotel.hotel_id}
+                hotel={hotel}
+                onClick={() => setSelectedHotel(hotel)}
+              />
             ))}
           </div>
         </div>
       </div>
+
+      {selectedHotel && parsedParams && (
+        <HotelDetailModal
+          hotel={selectedHotel}
+          arrivalDate={parsedParams.arrivalDate}
+          departureDate={parsedParams.departureDate}
+          adults={parsedParams.adults}
+          onClose={() => setSelectedHotel(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/types/flightOffersType.ts
+++ b/src/types/flightOffersType.ts
@@ -79,6 +79,8 @@ export interface FlightOffer {
   price: FlightOfferPrice;
   brandedFareInfo?: BrandedFareInfo;
   segments: FlightSegment[];
+  /** 백엔드가 주입하는 Booking.com 검색 딥링크 */
+  bookingUrl?: string;
 }
 
 /** searchFlights(offers) 응답의 data 필드 */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,10 @@ import path from "path";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), svgr()],
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- Add hotel detail modal with room details and Booking.com reservation links
- Wire hotel cards to open details and pass flight booking deeplinks into fare actions
- Set Vite dev server port to 5173

## Test
- npm run build